### PR TITLE
Update veldrid url in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/mellinoe/imgui.net
 [submodule "ext/veldrid"]
 	path = ext/veldrid
-	url = https://github.com/mellinoe/veldrid
+	url = https://github.com/mellinoe/veldrid-legacy
 [submodule "ext/sharpfont"]
 	path = ext/sharpfont
 	url = https://github.com/mellinoe/sharpfont


### PR DESCRIPTION
I found your `CrazyCore` project and attempted to clone but ran into issues when it came to pulling in veldrid. After some digging I discovered you moved the veldrid this engine uses to `Veldrid-Legacy`. This PR updates the `.gitmodules` file to point to the correct repo so clone works.